### PR TITLE
修复导入csv时遇到换行符和逗号时解析错误的BUG

### DIFF
--- a/EngageXml/EngageXml/MSBT.cs
+++ b/EngageXml/EngageXml/MSBT.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -1137,15 +1137,14 @@ namespace EngageXml
             using (var fs = new FileStream(csvPath, FileMode.Open))
             using (var sr = new StreamReader(fs))
             {
-                string[] kv;
-                string line, key, value;
-                line = sr.ReadLine();
-                while (line != null)
+                string line = null;
+                while ((line = ReadRN(sr)) !=null)
                 {
                     line = line.Replace("\\n", "\n");
-                    kv = line.Split(',');
-                    key = kv[0].Trim();
-                    value = kv[1].Trim();
+                    int dotIndx = line.IndexOf(",");
+
+                    string key = line.Substring(0, dotIndx).Trim();
+                    string value = line.Substring(dotIndx + 1).Trim();
                     if (key.Length <= LabelMaxLength && Regex.IsMatch(key, LabelFilter))
                     {
                         Label lbl = HasLabel(key);
@@ -1164,9 +1163,45 @@ namespace EngageXml
                     {
                         throw new Exception("Invalid Label!");
                     }
-                    line = sr.ReadLine();
                 }
             }
+        }
+
+
+        public static string ReadRN(StreamReader sr)
+        {
+            string tmp = "";
+            int c = 0;
+            while( (c = sr.Read()) !=-1)
+            {
+               char chr = Convert.ToChar(c);
+                if(chr != '\r')
+                {
+                    tmp += chr;
+                }
+                else
+                {
+                    c = sr.Read();
+                    if(c == -1)
+                    {
+                        tmp += '\r';
+                        break;
+                    }else if(c == '\n')
+                    {
+                        break;
+                    }
+                    else
+                    {
+                        tmp += '\r' + Convert.ToChar(c);
+                    }
+                }
+            }
+
+            if(tmp == "")
+            {
+                tmp = null;
+            }
+            return tmp;
         }
 	}
 }

--- a/EngageXml/EngageXml/Program.cs
+++ b/EngageXml/EngageXml/Program.cs
@@ -1,4 +1,4 @@
-﻿using AssetsTools.NET;
+using AssetsTools.NET;
 using AssetsTools.NET.Extra;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
@@ -500,15 +500,14 @@ namespace EngageXml
             using (var fs = new FileStream(csvPath, FileMode.Open))
             using (var sr = new StreamReader(fs))
             {
-                string[] kv;
-                string line, key, value;
-                line = sr.ReadLine();
-                while (line != null) 
+                string line = null;
+                while ((line = MSBT.ReadRN(sr))!=null) 
                 {
                     line = line.Replace("\\n", "\n");
-                    kv = line.Split(',');
-                    key = kv[0].Trim();
-                    value = kv[1].Trim();
+                    int dotIndx = line.IndexOf(",");
+
+                    string key = line.Substring(0, dotIndx).Trim();
+                    string value = line.Substring(dotIndx + 1).Trim();
                     if (key.Length <= MSBT.LabelMaxLength && Regex.IsMatch(key, MSBT.LabelFilter))
                     {
                         Label lbl = msbt.HasLabel(key);
@@ -526,7 +525,6 @@ namespace EngageXml
                     {
                         throw new Exception("Invalid Label!");
                     }
-                    line = sr.ReadLine();
                 }
             }
             AM.UnloadBundleFile(bundlePath);


### PR DESCRIPTION
新增ReadRN用以强制读取\r\n换行符
修改key和value读取逻辑,避免value中可能存在逗号导致value解析不全